### PR TITLE
Add responsive styles to LocalizarEstabelecimento

### DIFF
--- a/app/(app)/localizar.tsx
+++ b/app/(app)/localizar.tsx
@@ -1,5 +1,12 @@
 import React, { useEffect, useState, useContext } from "react";
-import { View, Text, TextInput, Pressable, ScrollView } from "react-native";
+import {
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  ScrollView,
+  useWindowDimensions,
+} from "react-native";
 import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
@@ -32,6 +39,7 @@ export default function LocalizarEstabelecimento() {
   const [busca, setBusca] = useState("");
   const [tipoSelecionado, setTipoSelecionado] = useState<string>("Todos");
   const { userToken } = useContext(AuthContext);
+  const isSmallScreen = useWindowDimensions().width < 768;
 
   const buscarViaGoogle = async (latitude: number, longitude: number) => {
     try {
@@ -114,12 +122,12 @@ export default function LocalizarEstabelecimento() {
   });
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, isSmallScreen && styles.containerMobile]}>
       <motion.div
         initial={{ x: -100, opacity: 0 }}
         animate={{ x: 0, opacity: 1 }}
         transition={{ duration: 0.6 }}
-        style={styles.sidebar}
+        style={[styles.sidebar, isSmallScreen && styles.sidebarMobile]}
       >
         <Text style={styles.logo}>🌱 VegConnect</Text>
 

--- a/src/styles/LocalizarEstabelecimentoStyles.ts
+++ b/src/styles/LocalizarEstabelecimentoStyles.ts
@@ -6,6 +6,9 @@ export const styles = StyleSheet.create({
     flexDirection: "row",
     backgroundColor: "#003B2A",
   },
+  containerMobile: {
+    flexDirection: "column",
+  },
   sidebar: {
     width: 340,
     padding: 24,
@@ -15,6 +18,9 @@ export const styles = StyleSheet.create({
     display: "flex",
     flexDirection: "column",
     gap: 12,
+  },
+  sidebarMobile: {
+    width: "100%",
   },
   logo: {
     fontSize: 28,


### PR DESCRIPTION
## Summary
- import `useWindowDimensions` in `localizar`
- detect small screen width and adjust styles
- define `containerMobile` and `sidebarMobile` style variants

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: eslint module not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_684257941a98832e9ed66aa9896fa025